### PR TITLE
Upgrade compatible with latest Beanshell source.

### DIFF
--- a/test/bsh/linter/LinterTest.java
+++ b/test/bsh/linter/LinterTest.java
@@ -18,53 +18,61 @@ public class LinterTest {
 	 */
 	@Test
 	public void TestScript1() throws IOException {
-		FileInputStream fis = new FileInputStream(new File("scripts/Test1.bsh"));
-		BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-		
-		Map<String,String> errors = Linter.lint(br);
-		Assert.assertEquals(1, errors.size());
-		Assert.assertTrue(errors.containsKey("5"));
+		try (FileInputStream fis = new FileInputStream(new File("scripts/Test1.bsh"));
+				BufferedReader br = new BufferedReader(new InputStreamReader(fis))) {
+
+			Map<String,String> errors = Linter.lint(br);
+			Assert.assertEquals(1, errors.size());
+			Assert.assertTrue(errors.containsKey("5"));
+			Assert.assertEquals("Encountered:  <IDENTIFIER> \"someMethod\"", errors.get("5"));
+		}
 	}
-	
+
 	/**
 	 * Test for multiple errors in a script
 	 * @throws IOException
 	 */
 	@Test
 	public void TestScript2() throws IOException {
-		FileInputStream fis = new FileInputStream(new File("scripts/Test2.bsh"));
-		BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-		
-		Map<String,String> errors = Linter.lint(br);
-		Assert.assertEquals(3, errors.size());
-		Assert.assertTrue(errors.containsKey("3"));
-		Assert.assertTrue(errors.containsKey("8"));
-		Assert.assertTrue(errors.containsKey("11"));
+		try (FileInputStream fis = new FileInputStream(new File("scripts/Test2.bsh"));
+				BufferedReader br = new BufferedReader(new InputStreamReader(fis))) {
+
+			Map<String,String> errors = Linter.lint(br);
+			Assert.assertEquals(3, errors.size());
+			Assert.assertTrue(errors.containsKey("3"));
+			Assert.assertEquals("Encountered:  \")\" \")\"", errors.get("3"));
+			Assert.assertTrue(errors.containsKey("8"));
+			Assert.assertEquals("Encountered: \"\\n\" (10), after : \"\\\"Missing double quotes;\"", errors.get("8"));
+			Assert.assertTrue(errors.containsKey("11"));
+			Assert.assertEquals("Encountered:  \"(\" \"(\"", errors.get("11"));
+		}
 	}
-	
+
 	/**
 	 * Test for no errors in the script
 	 * @throws IOException
 	 */
 	@Test
 	public void TestScript3() throws IOException {
-		FileInputStream fis = new FileInputStream(new File("scripts/Test3.bsh"));
-		BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-		
-		Map<String,String> errors = Linter.lint(br);
-		Assert.assertEquals(0, errors.size());
+		try (FileInputStream fis = new FileInputStream(new File("scripts/Test3.bsh"));
+				BufferedReader br = new BufferedReader(new InputStreamReader(fis))) {
+
+			Map<String,String> errors = Linter.lint(br);
+			Assert.assertEquals(0, errors.size());
+		}
 	}
-	
+
 	/**
 	 * Test for if-else and do-while statements
 	 * @throws IOException
 	 */
 	@Test
 	public void TestScript4() throws IOException {
-		FileInputStream fis = new FileInputStream(new File("scripts/Test4.bsh"));
-		BufferedReader br = new BufferedReader(new InputStreamReader(fis));
-		
-		Map<String,String> errors = Linter.lint(br);
-		Assert.assertEquals(0, errors.size());
+		try (FileInputStream fis = new FileInputStream(new File("scripts/Test4.bsh"));
+				BufferedReader br = new BufferedReader(new InputStreamReader(fis))) {
+
+			Map<String,String> errors = Linter.lint(br);
+			Assert.assertEquals(0, errors.size());
+		}
 	}
 }


### PR DESCRIPTION
Fixed error message parsing as per changes from BeanShell upstream.

Works now against latest develop source at branch merge-fork-beanshell2 which will be released as BeanShell 3.0 at some point.

Added additional asserts to complete unit tests.

I was playing around with the Token Manager and found that it would throw a lexical error due to the missing closing quote `"` and was able to parse the `TokenManagerException` alongside the existing `ParserException` errors to retrieve the message which now reads.

```
       Encountered: "\n" (10), after : "\"Missing double quotes;"
```

To avoid cascading issues due to the failed token and continue parsing the remaining code I found success by replacing the failed token with a `;` semi colon or empty statement. Token manager happily resumes parsing without any further complaints.

I am really grateful to have stumbled on this, thank you very much! I have been wondering for quite a while how we were going to manage syntax highlighting and finally I have the answer, with token manager of course. Great job on this little gem and many thanks for the learning experience.

P.S> Would you be ok with me adding this to the [beanshell/beanshell](/beanshell/beanshell) source?